### PR TITLE
ci: test docker and verify action img

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish action
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  IMAGE_NAME: action
+  REGISTRY: ghcr.io
+
+jobs:
+  test-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Check that the image builds
+        run: docker build . --file Dockerfile
+  validate-action:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4.1.1
+      # This checks that .github/workflows/cmd-action.yml is pointing towards the main branch
+      # as, during development, we change this to use the code from the test branch and
+      # we may forget to set it back to main
+      - name: Validate that action points to main branch
+        run: |
+          BRANCH=$(yq '.jobs.review-approvals.steps[2].uses' $FILE_NAME | cut -d "@" -f2)
+          # If the branch is not the main branch
+          if [ "$BRANCH" != "$GITHUB_BASE_REF" ]; then
+            echo "Action points to $BRANCH. It has to point to $GITHUB_BASE_REF instead!"
+            exit 1
+          else
+            echo "Action is correctly pointing to $GITHUB_BASE_REF"
+          fi
+        env:
+          FILE_NAME: ".github/workflows/cmd-action.yml"


### PR DESCRIPTION
Added script to verify that the github action is pointing toward the main branch (or a specific docker image) as, in development, we may forget to set this field back.

Added step to evaluate that docker image builds