### PR TITLE
Added ability to make push trigger actions

### DIFF
--- a/.github/workflows/cmd-action.yml
+++ b/.github/workflows/cmd-action.yml
@@ -29,12 +29,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1.9.2
+        with:
+          app-id: ${{ secrets.CMD_APP_ID }}
+          private-key: ${{ secrets.CMD_APP_KEY }}
       - uses: paritytech/cmd-action/run@main
         with:
           branch: ${{ needs.cmd-check.outputs.branch }}
           command: ${{ matrix.command.command }}
           name: ${{ matrix.command.name }}
           pr-number: ${{ github.event.issue.number }}
+          token: ${{ steps.generate_token.outputs.token }}
         # If you need to push your changes you can do so like this
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           FILE_NAME: ".github/workflows/cmd-action.yml"
       - name: Validate that cmd-run points to main branch
         run: |
-          BRANCH=$(yq '.jobs.cmd-run.steps[1].uses' $FILE_NAME | cut -d "@" -f2)
+          BRANCH=$(yq '.jobs.cmd-run.steps[2].uses' $FILE_NAME | cut -d "@" -f2)
           # If the branch is not the main branch
           if [ "$BRANCH" != "$GITHUB_BASE_REF" ]; then
             echo "Action points to $BRANCH. It has to point to $GITHUB_BASE_REF instead!"

--- a/README.md
+++ b/README.md
@@ -36,12 +36,20 @@ jobs:
         command: ${{ fromJson(needs.cmd-check.outputs.commands) }}
     name: Run command
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1.9.2
+        with:
+          app-id: ${{ secrets.CMD_APP_ID }}
+          private-key: ${{ secrets.CMD_APP_KEY }}
       - uses: paritytech/cmd-action/run@main
         with:
           branch: ${{ needs.cmd-check.outputs.branch }}
           command: ${{ matrix.command.command }}
           name: ${{ matrix.command.name }}
           pr-number: ${{ github.event.issue.number || github.event.pull_request.number }}
+          # If you want to push from a specific account (and trigger PR checks)
+          token: ${{ steps.generate_token.outputs.token }}
         # If you need to push your changes you can do so like this
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/run/action.yml
+++ b/run/action.yml
@@ -13,6 +13,9 @@ inputs:
   pr-number:
     description: "Number of the PR"
     required: true
+  token:
+    description: "GitHub token"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -20,6 +23,7 @@ runs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
+          token: ${{ inputs.token }}
       - name: Generate script
         shell: bash
         # Here it would get the script from previous step


### PR DESCRIPTION
From the [git-auto-commit Action's documentation](https://github.com/stefanzweifel/git-auto-commit-action/tree/v5/?tab=readme-ov-file#commits-made-by-this-action-do-not-trigger-new-workflow-runs):
> The resulting commit will not trigger another GitHub Actions Workflow run.

We need to use `actions/checkout` with a token to make this action push trigger actions.

Another option, as this brings too many step for the custom step, is to remove the `actions/checkout` from the `run/action.yml` and have users add it manually.

WDYT?